### PR TITLE
Fix: GitHub Actions workflow hanging on mkdocs serve

### DIFF
--- a/.devcontainer/requirements.sh
+++ b/.devcontainer/requirements.sh
@@ -3,4 +3,4 @@
 pip install mkdocs-material \
 	mkdocs-minify-plugin mkdocs-redirects mkdocs-git-revision-date-localized-plugin mkdocs-git-committers-plugin-2 mkdocs-video
 
-echo "Start project with: `python3 -m mkdocs serve`"
+echo "Start project with: python3 -m mkdocs serve"


### PR DESCRIPTION
## Task:

Fixes GitHub Actions workflow hanging during build process

## Changelog (AI Generated):

- Fixed command substitution in `.devcontainer/requirements.sh` that was causing `mkdocs serve` to execute during CI/CD
- Changed backticks to plain text in echo statement to prevent unintended command execution
- This was causing the GitHub Actions workflow to hang indefinitely waiting for the development server to stop

## Screenshots / Videos:

### Before (causes hang):
```bash
echo "Start project with: `python3 -m mkdocs serve`"  # Executes the command!
```

### After (works correctly):
```bash
echo "Start project with: python3 -m mkdocs serve"   # Just prints the text
```

## Follow up tasks:

- Monitor next PR/push to ensure GitHub Actions completes successfully
- No further changes needed

## Technical Details:

The backticks (`` ` ``) in bash cause command substitution, meaning the command inside them gets executed and its output is inserted into the string. This was causing the development server to start during the CI/CD pipeline, which would never terminate, causing the workflow to hang.