### PR TITLE
fix(guides): correct unit military rank requirements

### DIFF
--- a/docs/guides/player-rank.md
+++ b/docs/guides/player-rank.md
@@ -11,155 +11,61 @@ including:
 -   Unlocked Units to train.
 
 You always start the game as a level 5 Recruit, with access to Bradley and Bazooka units, and evolve
-from there. The miltary ranks are Private, Sergeant, Captain, Major, Lieutenant, General and Elite
+from there. The military ranks are Private, Sergeant, Captain, Major, Lieutenant, General and Elite
 General.
 
 **Note:** The "Army Budget" shown below refers to the maximum individual unit type limits per rank, not your total army size. Your total [Normal Unit capacity](unit-train.md#unit-capacity-system) is determined by the number of [bases](bases.md) you own (10,000 units per base).
 
-Below you can find the rewards for each military rank.
+## Rank Progression
 
-## Recruit
-
-**Army Budget:** 750 per Normal Unit type and 15 per Supreme Unit type.
-
-| Level  |   XP   | Unlocked Units | WWO-Influence | Iron  | Units Received  |
-| :----: | :----: | :------------: | :-----------: | :---: | :-------------: |
-| **6**  | 2.500  |   Black Hawk   |       1       | 1.000 | 1500 Black Hawk |
-| **7**  | 5.000  |       -        |       1       | 1.000 |        -        |
-| **8**  | 10.000 |     Akula      |       1       | 1.000 |   1500 Akula    |
-| **9**  | 15.000 |       -        |       1       | 1.000 |        -        |
-| **10** | 20.000 |    Soldier     |       1       | 1.000 |  1500 Soldier   |
-| **11** | 25.000 |    Stinger     |       1       | 1.000 |  1500 Stinger   |
-| **12** | 32.500 |     Marine     |       1       | 1.000 |    10 Marine    |
-| **13** | 40.000 |       -        |       1       | 1.000 |        -        |
-| **14** | 47.500 |    Pomornik    |       1       | 1.000 |  1500 Pomornik  |
-| **15** | 55.000 |       -        |       1       | 1.000 |        -        |
-| **16** | 65.000 |    Bakhcha     |       1       | 1.000 |  1500 Backcha   |
-| **17** | 75.000 |       -        |       1       | 1.000 |        -        |
-
-## Private
-
-**Army Budget:** 1,500 per Normal Unit type and 20 per Supreme Unit type.
-
-| Level  |   XP    | Unlocked Units | WWO-Influence | Iron  | Units Received |
-| :----: | :-----: | :------------: | :-----------: | :---: | :------------: |
-| **18** | 90.000  |    Arleigh     |       2       | 1.500 |  1500 Arleigh  |
-| **19** | 105.000 |       -        |       2       | 1.500 |       -        |
-| **20** | 120.000 |     Gepard     |       2       | 1.500 |  1500 Gepard   |
-| **21** | 135.000 |     Reaper     |       2       | 1.500 |  1500 Reaper   |
-| **22** | 155.000 |       -        |       2       | 1.500 |       -        |
-| **23** | 175.000 |     Mortar     |       2       | 1.500 |   10 Mortar    |
-| **24** | 200.000 |      Lynx      |       2       | 1.500 |   1500 Lynx    |
-
-## Sergeant
-
-**Army Budget:** 2,250 per Normal Unit type and 25 per Supreme Unit type.
-
-| Level  |   XP    | Unlocked Units | WWO-Influence | Iron  | Units Received |
-| :----: | :-----: | :------------: | :-----------: | :---: | :------------: |
-| **25** | 250.000 |    General     |       2       | 2.000 |       -        |
-| **26** | 300.000 |    Dongfeng    |       2       | 2.000 | 1500 Dongfeng  |
-| **27** | 350.000 |     ZU-23      |       2       | 2.000 |    10 ZU-23    |
-| **28** | 400.000 |    Chengdu     |       2       | 2.000 |  1500 Chengdu  |
-| **29** | 475.000 |      F-35      |       2       | 2.000 |    10 F-35     |
-
-## Captain
-
-**Army Budget:** 3,000 per Normal Unit type and 30 per Supreme Unit type.
-
-| Level  |    XP     | Unlocked Units | WWO-Influence | Iron  | Units Received |
-| :----: | :-------: | :------------: | :-----------: | :---: | :------------: |
-| **30** |  550.000  |    Leopard     |       3       | 3.000 |   10 Leopard   |
-| **31** |  660.000  |       -        |       3       | 3.000 |       -        |
-| **32** |  775.000  |    Bastion     |       3       | 3.000 |   10 Bastion   |
-| **33** |  950.000  |     Daring     |       3       | 3.000 |   10 Daring    |
-| **34** | 1.140.000 |       -        |       3       | 3.000 |       -        |
-
-## Major
-
-**Army Budget:** 3,750 per Normal Unit type and 35 per Supreme Unit type.
-
-| Level  |    XP     | Unlocked Units | WWO-Influence | Iron  | Units Received |
-| :----: | :-------: | :------------: | :-----------: | :---: | :------------: |
-| **35** | 1.350.000 |     Apache     |       4       | 4.000 |   10 Apache    |
-| **36** | 1.650.000 |       -        |       4       | 4.000 |       -        |
-| **37** | 1.950.000 |    Panther     |       4       | 4.000 |   10 Panther   |
-| **38** | 2.350.000 |       -        |       4       | 4.000 |       -        |
-| **39** | 2.850.000 |    Zumwalt     |       4       | 4.000 |   10 Zumwalt   |
-
-## Lieutenant
-
-**Army Budget:** 4,500 per Normal Unit type and 40 per Supreme Unit type.
-
-| Level  |    XP     | Unlocked Units | WWO-Influence | Iron  | Units Received |
-| :----: | :-------: | :------------: | :-----------: | :---: | :------------: |
-| **40** | 3.400.000 |     Sniper     |      60       | 6.000 |   10 Sniper    |
-| **41** | 4.050.000 |      SAM       |      60       | 6.000 |     10 SAM     |
-| **42** | 4.900.000 |     Abrams     |      60       | 6.000 |   10 Abrams    |
-| **43** | 5.750.000 |  Los Angeles   |      60       | 6.000 | 10 Los Angeles |
-| **44** | 7.000.000 |      F-22      |      60       | 6.000 |    10 F-22     |
-
-## General
-
-**Army Budget:** 5,250 per Normal Unit type and 45 per Supreme Unit type.
-
-| Level  |     XP     | Unlocked Units | WWO-Influence |  Iron  | Units Received |
-| :----: | :--------: | :------------: | :-----------: | :----: | :------------: |
-| **45** | 8.500.000  |   B-2 Bomber   |      10       | 10.000 | 10 B-2 Bomber  |
-| **46** | 10.000.000 |       -        |      10       | 10.000 |       -        |
-| **47** | 12.250.000 |       -        |      10       | 10.000 |       -        |
-| **48** | 14.750.000 |       -        |      10       | 10.000 |       -        |
-| **49** | 17.250.000 |       -        |      10       | 10.000 |       -        |
-
-## Elite General
-
-**Army Budget:** 6,000 per Normal Unit type and 50 per Supreme Unit type.
-
-| Level  |     XP     | Unlocked Units | WWO-Influence |  Iron  | Units Received |
-| :----: | :--------: | :------------: | :-----------: | :----: | :------------: |
-| **50** | 20.000.000 |       -        |      20       | 20.000 |       -        |
+| Rank | Levels | Army Budget (Normal) | Army Budget (Supreme) |
+| :--- | :----: | :------------------: | :-------------------: |
+| Recruit | 5-17 | 750 | 15 |
+| Private | 18-24 | 1,500 | 20 |
+| Sergeant | 25-29 | 2,250 | 25 |
+| Captain | 30-34 | 3,000 | 30 |
+| Major | 35-39 | 3,750 | 35 |
+| Lieutenant | 40-44 | 4,500 | 40 |
+| General | 45-49 | 5,250 | 45 |
+| Elite General | 50 | 6,000 | 50 |
 
 ## Unit Military Rank Requirements
 
 Below is a complete list of all active units and the military rank required to unlock them, sorted by rank:
 
-| Unit           | Military Rank |
-| :------------- | :-----------: |
-| Infantry       |       1       |
-| Bradley        |       2       |
-| Bazooka        |       3       |
-| Stinger        |       4       |
-| Bakhcha        |       5       |
-| Blackhawk      |       6       |
-| Akula          |       7       |
-| LG1            |       8       |
-| Reaper         |       9       |
-| Chengdu        |      10       |
-| Sniper         |      11       |
-| Arleigh Burke  |      12       |
-| Christy        |      13       |
-| Mortar         |      14       |
-| Gepard         |      15       |
-| Lynx           |      16       |
-| Abrams         |      17       |
-| Chinook        |      17       |
-| Dongfeng       |      18       |
-| Pomornik       |      19       |
-| ZU23           |      20       |
-| Leopard        |      22       |
-| General        |      25       |
-| Apache         |      26       |
-| Los Angeles    |      28       |
-| Charles Gaulle |      30       |
-| General Boxer  |      32       |
-| Marine         |      32       |
-| F35            |      34       |
-| F22            |      36       |
-| Daring         |      38       |
-| Panther        |      40       |
-| Special Forces |      40       |
-| Bastion P      |      42       |
-| Mobile SAM     |      44       |
-| C17            |      46       |
-| Zumwalt        |      46       |
-| B2             |      48       |
+| Unit | Military Rank |
+| :--- | :-----------: |
+| [Soldier](units-normal.md#soldier) | 1 |
+| [Bradley](units-normal.md#bradley) | 2 |
+| [Bazooka](units-normal.md#bazooka) | 3 |
+| [Stinger](units-normal.md#stinger) | 4 |
+| [Bakhcha](units-normal.md#bakhcha) | 5 |
+| [Black Hawk](units-normal.md#black-hawk) | 6 |
+| [Akula](units-normal.md#akula) | 7 |
+| [LG1](units-normal.md#lg1) | 8 |
+| [Reaper](units-normal.md#reaper) | 9 |
+| [Chengdu](units-normal.md#chengdu) | 10 |
+| [Sniper](units-supreme.md#sniper) | 11 |
+| [Arleigh Burke](units-normal.md#arleigh-burke) | 12 |
+| [Christy](units-normal.md#christy) | 13 |
+| [Mortar](units-supreme.md#mortar) | 14 |
+| [Gepard](units-normal.md#gepard) | 15 |
+| [Lynx](units-normal.md#lynx) | 16 |
+| [Abrams](units-supreme.md#abrams) | 17 |
+| [Dongfeng](units-normal.md#dongfeng) | 18 |
+| [Pomornik](units-normal.md#pomornik) | 19 |
+| [General](units-tactic.md#general) | 20 |
+| [Leopard](units-supreme.md#leopard) | 22 |
+| [ZU-23](units-supreme.md#zu-23) | 25 |
+| [Apache](units-supreme.md#apache) | 26 |
+| [Los Angeles](units-supreme.md#los-angeles) | 28 |
+| [Marine](units-supreme.md#marine) | 32 |
+| [F-35](units-supreme.md#f-35) | 34 |
+| [F-22](units-supreme.md#f-22) | 36 |
+| [Daring](units-supreme.md#daring) | 38 |
+| [Panther](units-supreme.md#panther) | 39 |
+| [Special Forces](units-tactic.md#special-forces) | 40 |
+| [Bastion](units-supreme.md#bastion) | 42 |
+| [Mobile SAM](units-supreme.md#mobile-sam) | 44 |
+| [Zumwalt](units-supreme.md#zumwalt) | 46 |
+| [B-2 Bomber](units-supreme.md#b-2-bomber) | 48 |


### PR DESCRIPTION
## Summary

- Fix all unit minRank values to match actual code values from `unit.definition.tsx`
- Remove deprecated reward tables (XP/level progression per rank) - these were outdated
- Remove deprecated units from the list (Chinook, Charles Gaulle, General Boxer, C17)
- Add clickable links to unit guide pages for each unit in the table
- Add consolidated rank progression table showing army budget per rank
- Fix General unlock rank from 25 → 20 (verified against code)
- Fix typo: "miltary" → "military"

## Issues Resolved

- Resolves Chilltime/world-war-online-webapp#2318
- Resolves Chilltime/world-war-online-webapp#2320
- Resolves Chilltime/world-war-online-webapp#2321

## Changes Made

| Before | After |
|--------|-------|
| General at rank 25 | General at rank 20 |
| 37 units listed (including deprecated) | 34 active units only |
| No links to unit pages | All units link to their guide pages |
| Detailed XP tables per level | Simplified rank progression table |

## Verification

All minRank values were extracted directly from `/src/domains/unit/util/unit.definition.tsx` and cross-referenced with the `units-tactic.md` guide which already had the correct value (rank 20) for General.

🤖 Generated with [Claude Code](https://claude.com/claude-code)