### PR TITLE
fix: Update footer copyright year to 2026

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,7 +7,7 @@ site_description: >-
 site_author: World War Online
 
 # Copyright
-copyright: Copyright &copy; 2025 Chilltime, Lda.
+copyright: Copyright &copy; 2026 Chilltime, Lda.
 
 # Configuration
 theme:


### PR DESCRIPTION
## Task:

Update the guides footer copyright year from 2025 to 2026.

## Changelog:

- Updated copyright year in `mkdocs.yml` from 2025 to 2026

## Screenshots / Videos:

Not applicable - configuration change only

## Follow up tasks:

None